### PR TITLE
build(pre-commit): Ignore coverage folder in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+coverage
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
Add coverage folder to .gitignore file. Coverage folder is the result folder of jest tests.